### PR TITLE
[codex] 修复聊天切换滚动位置跳动

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pantry",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pantry",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "hasInstallScript": true,
       "dependencies": {
         "@tesseract.js-data/chi_sim": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pantry",
   "productName": "茶话间",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "茶话间（Pantry）—— 纯内网、基于 IP 的局域网即时通讯与文件传输工具",
   "private": true,
   "main": "./out/main/index.js",

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -62,10 +62,15 @@ function applyWindowTitle(next: SettingsView | null): void {
   document.title = nick ? `${nick}-🍵Pantry` : '茶话间'
 }
 
+function onVisibilityChange(): void {
+  if (document.visibilityState === 'hidden') chatStore.forgetConversationScrolls()
+}
+
 onMounted(async () => {
   void peersStore.init()
   void chatStore.init()
   void groupsStore.init()
+  document.addEventListener('visibilitychange', onVisibilityChange)
   info.value = await window.pantry.getAppInfo()
   settings.value = await window.pantry.getSettings()
   applyAppearance(settings.value)
@@ -79,6 +84,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  document.removeEventListener('visibilitychange', onVisibilityChange)
   stopSettings?.()
 })
 </script>

--- a/src/renderer/src/components/ChatPane.vue
+++ b/src/renderer/src/components/ChatPane.vue
@@ -96,6 +96,8 @@ const nudgeNow = ref(Date.now())
 const nudgeFeedback = ref<{ text: string; kind: 'ok' | 'warn' } | null>(null)
 let nudgeFeedbackTimer: ReturnType<typeof setTimeout> | null = null
 let nudgeRetryTimer: ReturnType<typeof setInterval> | null = null
+let applyingConversationScroll = false
+const SCROLL_BOTTOM_THRESHOLD = 24
 
 const isGroup = computed(() => chatStore.activeConv?.type === 'group')
 const group = computed(() =>
@@ -243,9 +245,11 @@ onMounted(async () => {
     settings.value = next
     void nextTick(refreshInputFont)
   })
+  applyConversationScroll()
 })
 
 onUnmounted(() => {
+  rememberConversationScroll()
   document.removeEventListener('mousedown', onDocumentPointerDown)
   if (historySearchTimer) clearTimeout(historySearchTimer)
   if (peerProfileSavedTimer) clearTimeout(peerProfileSavedTimer)
@@ -311,19 +315,74 @@ function needSeparator(msg: MessageView, index: number): boolean {
 function scrollToBottom(): void {
   void nextTick(() => {
     const el = scrollArea.value
-    if (el) el.scrollTop = el.scrollHeight
+    if (el) applyScrollTop(el.scrollHeight)
   })
 }
 
-watch(() => chatStore.activeConvId, scrollToBottom)
-// 只在"末尾追加"时贴底（向上加载历史是前插，不该滚动）
+function isNearBottom(el = scrollArea.value): boolean {
+  if (!el) return true
+  return el.scrollHeight - el.clientHeight - el.scrollTop <= SCROLL_BOTTOM_THRESHOLD
+}
+
+function rememberConversationScroll(convId = chatStore.activeConvId): void {
+  const el = scrollArea.value
+  if (!el || !convId) return
+  chatStore.rememberConversationScroll(convId, el.scrollTop, isNearBottom(el))
+}
+
+function applyScrollTop(top: number): void {
+  const el = scrollArea.value
+  if (!el) return
+  applyingConversationScroll = true
+  el.scrollTop = top
+  window.requestAnimationFrame(() => {
+    applyingConversationScroll = false
+    rememberConversationScroll()
+  })
+}
+
+function applyConversationScroll(): void {
+  const convId = chatStore.activeConvId
+  const mode = chatStore.openScrollMode
+  if (!convId || mode === 'target') return
+  void nextTick(() => {
+    if (chatStore.activeConvId !== convId) return
+    const el = scrollArea.value
+    if (!el) return
+    const saved = chatStore.scrollPositions[convId]
+    if (mode === 'latest' || !saved || saved.atBottom) {
+      applyScrollTop(el.scrollHeight)
+      return
+    }
+    applyScrollTop(Math.min(saved.top, Math.max(0, el.scrollHeight - el.clientHeight)))
+  })
+}
+
+watch(
+  () => chatStore.activeConvId,
+  (_id, oldId) => {
+    if (oldId) rememberConversationScroll(oldId)
+  }
+)
+
+watch(() => chatStore.openScrollRun, applyConversationScroll)
+
+// 只在"末尾追加"且用户本来在底部附近时贴底；自己发送的消息始终跟随到底部。
 watch(
   () => {
     const list = chatStore.activeMessages
-    return list.length > 0 ? list[list.length - 1].id : ''
+    const tail = list[list.length - 1]
+    return {
+      convId: chatStore.activeConvId ?? '',
+      id: tail?.id ?? '',
+      isMine: tail?.isMine ?? false
+    }
   },
-  (id, oldId) => {
-    if (id && id !== oldId) scrollToBottom()
+  (next, old) => {
+    if (!old || !next.convId || next.convId !== old.convId || !next.id || next.id === old.id) {
+      return
+    }
+    if (isNearBottom() || next.isMine) scrollToBottom()
   }
 )
 // 搜索跳转高亮：滚动到目标消息居中
@@ -341,13 +400,16 @@ watch(
 /** 滚到顶部附近 → 向上加载更早历史，并保持视口位置不跳（F-MSG-5） */
 async function onScroll(): Promise<void> {
   const el = scrollArea.value
-  if (!el || el.scrollTop > 40 || loadingEarlier.value) return
+  if (!el) return
+  rememberConversationScroll()
+  if (applyingConversationScroll || el.scrollTop > 40 || loadingEarlier.value) return
   loadingEarlier.value = true
   const prevHeight = el.scrollHeight
   const loaded = await chatStore.loadEarlier()
   if (loaded > 0) {
     await nextTick()
     el.scrollTop = el.scrollHeight - prevHeight + el.scrollTop
+    rememberConversationScroll()
   }
   loadingEarlier.value = false
 }

--- a/src/renderer/src/stores/chat.ts
+++ b/src/renderer/src/stores/chat.ts
@@ -12,10 +12,26 @@ import type {
 let nudgeClearTimer: ReturnType<typeof setTimeout> | null = null
 let nudgeOpenRun = 0
 
+type ConversationOpenScrollMode = 'restore' | 'latest' | 'target'
+
+interface OpenConversationOptions {
+  scroll?: ConversationOpenScrollMode
+}
+
+interface ConversationScrollPosition {
+  top: number
+  atBottom: boolean
+}
+
 export const useChatStore = defineStore('chat', {
   state: () => ({
     convs: [] as ConversationView[],
     activeConvId: null as string | null,
+    /** 本次打开会话后消息区应如何定位（纯渲染层状态，决议 #111） */
+    openScrollMode: 'latest' as ConversationOpenScrollMode,
+    openScrollRun: 0,
+    /** convId → 离开会话时的滚动位置 */
+    scrollPositions: {} as Record<string, ConversationScrollPosition>,
     /** convId → 已加载消息（按 seq 升序） */
     messages: {} as Record<string, MessageView[]>,
     /** 搜索跳转后的高亮目标（短暂） */
@@ -70,7 +86,7 @@ export const useChatStore = defineStore('chat', {
       })
       window.pantry.onNudgeReceived((event) => {
         const run = ++nudgeOpenRun
-        void this.openConv(event.convId).then(() => {
+        void this.openConv(event.convId, { scroll: 'latest' }).then(() => {
           if (run !== nudgeOpenRun) return
           this.lastNudge = event
           if (nudgeClearTimer) clearTimeout(nudgeClearTimer)
@@ -83,7 +99,7 @@ export const useChatStore = defineStore('chat', {
       })
       // 点系统通知/托盘 → 直达对应会话（F-SYS-2），单聊群聊通用
       window.pantry.onOpenConv((convId) => {
-        void this.openConv(convId)
+        void this.openConv(convId, { scroll: 'latest' })
       })
       // 截图选择"发送"：发到当前会话（无可发送会话则只留在剪贴板）
       window.pantry.onCaptured((bytes) => {
@@ -93,7 +109,11 @@ export const useChatStore = defineStore('chat', {
     },
 
     /** 从通讯录或会话列表进入会话 */
-    async openPeer(peerNodeId: string): Promise<void> {
+    async openPeer(
+      peerNodeId: string,
+      options: OpenConversationOptions = { scroll: 'latest' }
+    ): Promise<void> {
+      const scroll = options.scroll ?? 'latest'
       const conv = await window.pantry.openConversation(peerNodeId)
       if (!conv) return
       this.upsertConversation(conv)
@@ -102,12 +122,14 @@ export const useChatStore = defineStore('chat', {
       if (!this.messages[conv.id]) {
         this.messages[conv.id] = await window.pantry.pageMessages(conv.id, null, 50)
       }
+      this.requestConversationScroll(scroll)
     },
 
     /** 按会话 id 打开（群会话 / 通知跳转通用） */
-    async openConv(convId: string): Promise<void> {
+    async openConv(convId: string, options: OpenConversationOptions = {}): Promise<void> {
+      const scroll = options.scroll ?? 'restore'
       if (convId.startsWith('single:')) {
-        await this.openPeer(convId.slice(7))
+        await this.openPeer(convId.slice(7), { scroll })
         return
       }
       this.activeConvId = convId
@@ -116,6 +138,7 @@ export const useChatStore = defineStore('chat', {
         this.messages[convId] = await window.pantry.pageMessages(convId, null, 50)
       }
       await window.pantry.markRead(convId)
+      this.requestConversationScroll(scroll)
     },
 
     /** 搜索结果跳转：载入目标前后窗口并短暂高亮（ui-design §6） */
@@ -135,6 +158,7 @@ export const useChatStore = defineStore('chat', {
       const tail = ctx[ctx.length - 1]
       this.viewingHistory = !(conv && tail && tail.ts >= conv.lastTs)
       this.highlightId = msgId || null
+      this.requestConversationScroll('target')
       setTimeout(() => {
         if (this.highlightId === msgId) this.highlightId = null
       }, 2600)
@@ -145,6 +169,23 @@ export const useChatStore = defineStore('chat', {
       if (!convId) return
       this.messages[convId] = await window.pantry.pageMessages(convId, null, 50)
       this.viewingHistory = false
+      this.requestConversationScroll('latest')
+    },
+
+    requestConversationScroll(mode: ConversationOpenScrollMode): void {
+      this.openScrollMode = mode
+      this.openScrollRun += 1
+    },
+
+    rememberConversationScroll(convId: string, top: number, atBottom: boolean): void {
+      this.scrollPositions[convId] = {
+        top: Math.max(0, Math.round(top)),
+        atBottom
+      }
+    },
+
+    forgetConversationScrolls(): void {
+      this.scrollPositions = {}
     },
 
     upsertConversation(conv: ConversationView): void {
@@ -165,6 +206,7 @@ export const useChatStore = defineStore('chat', {
       await window.pantry.removeConversation(convId)
       if (this.activeConvId === convId) this.activeConvId = null
       delete this.messages[convId]
+      delete this.scrollPositions[convId]
     },
 
     async loadEarlier(): Promise<number> {


### PR DESCRIPTION
## 变更
- 按会话记录聊天消息区滚动位置，前台切换会话时恢复离开位置。
- 首次打开、通知/托盘/震动直达，以及“回到最新”保留默认定位到最新消息。
- 当前会话收到新消息时，仅在用户本来接近底部或自己发送消息时自动贴底，避免阅读历史时被拉走。
- 版本号同步递增到 0.16.2。

## 根因
原 `ChatPane` 在 `activeConvId` 变化和最后一条消息变化时都会无条件 `scrollToBottom()`，导致切换不同聊天或阅读历史时被强行拉到底部。

## 验证
- `npm test`
- `npm run test:db`
- `npm run typecheck`
- `npm run build`
- `npm run smoke`
- `git diff --check`

## 说明
本轮按本地内部文档补充了决议 #111，但仓库 `.gitignore` 标注 `docs/` 为内部文档不公开到 GitHub，因此 PR 只包含公开代码与版本号变更。