### PR TITLE
fix(群聊): 补载历史引用消息

### DIFF
--- a/src/renderer/src/components/MessageRow.vue
+++ b/src/renderer/src/components/MessageRow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import {computed} from 'vue'
-import {MessageView, ReplyMeta} from '../../../shared/ipc'
+import { computed, ref, watch } from 'vue'
+import type { MessageView, ReplyMeta } from '../../../shared/ipc'
 import type { PkGame } from '../../../shared/pk'
 import { splitEmojiText } from '../utils/compat-emoji'
 import { messageStatusHint, shouldShowSeparator, textParts } from '../utils/message-row'
@@ -11,8 +11,8 @@ import FileCard from './FileCard.vue'
 import ImageBubble from './ImageBubble.vue'
 import PantryIcon from './PantryIcon.vue'
 import PkBubble from './PkBubble.vue'
-import {usePeersStore} from "../stores/peers";
-import {useChatStore} from "../stores/chat";
+import { useChatStore } from '../stores/chat'
+import { usePeersStore } from '../stores/peers'
 
 const props = defineProps<{
   msg: MessageView
@@ -64,11 +64,40 @@ function revealSystemTarget(): void {
 
 const peersStore = usePeersStore()
 const chatStore = useChatStore()
+const historicalReply = ref<MessageView | null>()
+
+watch(
+  [() => props.msg.replyTo, () => props.msg.convId],
+  async ([replyTo, convId], _previous, onCleanup) => {
+    historicalReply.value = undefined
+    if (!replyTo) return
+    const activeReply = chatStore.activeMessages.find((message) => message.id === replyTo)
+    if (activeReply) {
+      historicalReply.value = activeReply
+      return
+    }
+    let canceled = false
+    onCleanup(() => {
+      canceled = true
+    })
+    const message = await chatStore.getMessageById(replyTo)
+    if (!canceled) historicalReply.value = message?.convId === convId ? message : null
+  },
+  { immediate: true }
+)
+
 const replyMeta = computed((): ReplyMeta => {
   const replyTo = props.msg.replyTo
-  if (!replyTo) return {id: "", senderName: "", text: ""}
-  const replyMsg = chatStore.activeMessages.find((m) => m.id === replyTo)
-  if (!replyMsg) return {id: "", senderName: "", text: ""}
+  if (!replyTo) return { id: '', senderName: '', text: '' }
+  const replyMsg =
+    chatStore.activeMessages.find((message) => message.id === replyTo) ?? historicalReply.value
+  if (!replyMsg) {
+    return {
+      id: replyTo,
+      senderName: '',
+      text: historicalReply.value === undefined ? '正在加载原消息…' : '原消息不可用'
+    }
+  }
   let senderName = ''
   let text = replyMsg.text
   if (replyMsg.status === 'recalled') {
@@ -78,7 +107,7 @@ const replyMeta = computed((): ReplyMeta => {
   } else {
     senderName = peersStore.nameOf(replyMsg.senderId) || '未知成员'
   }
-  return {id: replyTo, senderName, text}
+  return { id: replyTo, senderName, text }
 })
 </script>
 

--- a/src/renderer/src/ui/message-file-visual.test.ts
+++ b/src/renderer/src/ui/message-file-visual.test.ts
@@ -44,6 +44,12 @@ describe('消息与文件视觉统一', () => {
     expect(ruleBody(messageSource, '.status .canceled')).toContain('color: var(--text-3)')
   })
 
+  it('历史引用按消息 ID 补载，缺失时显示可见提示', () => {
+    expect(messageSource).toContain('await chatStore.getMessageById(replyTo)')
+    expect(messageSource).toContain("message?.convId === convId ? message : null")
+    expect(messageSource).toContain("'原消息不可用'")
+  })
+
   it('普通文件到期按收发方向显示独立提示', () => {
     expect(fileCardSource).toContain("t.direction === 'out' ? '发送已到期' : '文件已过期'")
     expect(fileCardSource).toContain("if (expired > 0 && !active) return '发送已到期'")


### PR DESCRIPTION
## 变更
- 引用目标不在当前 50 条消息时，复用现有 `msg:get` 按 ID 补载
- 引用目标确实不存在时显示“原消息不可用”
- 增加历史引用渲染回归检查

## 验证
- `npm test`：103 个测试文件、630 项通过
- `npm run typecheck`
- `npm run check:version`
- `npm run check:docs`
- `npm run build`
- `npm run test:db`：含迁移及 20,000 条导入
- 独立 userData/端口 `npm run smoke`
- GUI 双客户端回环：建群、收发、引用回复通过
- GUI 长历史：原消息 seq 2 不在最新 50 条（seq 12–61），重启后引用文字正确显示，点击可跳回并高亮原消息